### PR TITLE
chore(translate): (Portuguese (Brazil))

### DIFF
--- a/core/src/main/res/values-pt-rBR/strings.xml
+++ b/core/src/main/res/values-pt-rBR/strings.xml
@@ -26,7 +26,7 @@
     <string name="genres">Gêneros</string>
     <string name="director">Diretor</string>
     <string name="writers">Escritor</string>
-    <string name="cast_amp_crew">Elenco e Equipe</string>
+    <string name="cast_amp_crew"><![CDATA[Elenco e Equipe]]></string>
     <string name="seasons">Temporadas</string>
     <string name="play_button_description">Reproduzir</string>
     <string name="trailer_button_description">Trailer</string>
@@ -190,4 +190,7 @@
     <string name="pref_player_chapter_markers">Marcadores de capítulo</string>
     <string name="pref_player_chapter_markers_summary">Exibir marcadores de capítulo na barra de tempo</string>
     <string name="collection_no_media">Esta coleção não contém nenhuma mídia</string>
+    <string name="pref_player_trickplay">Trickplay</string>
+    <string name="pref_player_trickplay_summary">Exibir imagens de visualização enquanto navega na barra de progresso</string>
+    <string name="sort_by_options_6">Aleatório</string>
 </resources>


### PR DESCRIPTION
Currently translated at 98.4% (194 of 197 strings)

Translation: Findroid/core
Translate-URL: https://weblate.jdtech.dev/projects/findroid/core/pt_BR/